### PR TITLE
Fix typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ declare module 'react-native-confirmation-code-field' {
 
   export default class ConfirmationCodeInput extends React.Component<
     ConfirmationCodeInputProps,
-    void
+    {}
   > {
     clear(): void;
   }


### PR DESCRIPTION
>  JSX element type 'ConfirmationCodeInput' is not a constructor function for JSX elements.
>   Types of property 'state' are incompatible.
>     Type 'void' is not assignable to type 'Readonly<{}>'.