### PR TITLE
Add formatCode prop to have the ability to format entered code

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,7 @@
     - [`cellProps: TextInputProps | ({index: number, isFocused: boolean, hasValue: boolean}) => ?TextInputProps`](#cellprops-textinputprops--index-number-isfocused-boolean-hasvalue-boolean--textinputprops)
   - [Other props](#other-props)
     - [`testID?: any`](#testid-any)
+    - [`formatCode?: (code: string) => string`](#formatcode-code-string--string)
   - [Functions](#functions)
     - [`focus() => void`](#focus--void)
     - [`blur() => void`](#blur--void)
@@ -140,6 +141,10 @@ Your function must will pass [TextInputProps](<(https://facebook.github.io/react
 ### `testID?: any`
 
 Help in test
+
+### `formatCode: (code: string) => string`
+
+Function that formats code on `onChangeText`.
 
 ## Functions
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ declare module 'react-native-confirmation-code-field' {
     containerProps?: ReactNative.ViewProps;
 
     testID?: any;
+    formatCode?: (code: string) => string;
   }
 
   export default class ConfirmationCodeInput extends React.Component<

--- a/src/components/ConfirmationCodeInput/ConfirmationCodeInput.js
+++ b/src/components/ConfirmationCodeInput/ConfirmationCodeInput.js
@@ -33,6 +33,7 @@ class ConfirmationCodeInput extends PureComponent<Props, State> {
     variant: 'border-box',
     keyboardType: 'number-pad',
     maskSymbol: '',
+    formatCode: null,
   };
 
   _input = createRef();
@@ -130,8 +131,12 @@ class ConfirmationCodeInput extends PureComponent<Props, State> {
   handlerOnTextChange = this.inheritTextInputMethod(
     'onTextChange',
     (text: string) => {
-      const codeValue = this.truncateString(text);
-      const { codeLength, onFulfill } = this.props;
+      const { codeLength, onFulfill, formatCode } = this.props;
+
+      const codeValue =
+        typeof formatCode === 'function'
+          ? formatCode(this.truncateString(text))
+          : this.truncateString(text);
 
       this.setState(
         {
@@ -284,6 +289,7 @@ if (process.env.NODE_ENV !== 'production') {
     ]),
     keyboardType: TextInputNative.propTypes.keyboardType,
     maskSymbol: PropTypes.string,
+    formatCode: PropTypes.func,
   };
 }
 

--- a/src/components/ConfirmationCodeInput/ConfirmationCodeInput.js
+++ b/src/components/ConfirmationCodeInput/ConfirmationCodeInput.js
@@ -233,6 +233,7 @@ class ConfirmationCodeInput extends PureComponent<Props, State> {
         ref={this._input}
         maxLength={codeLength}
         {...inputProps}
+        value={this.state.codeValue}
         autoFocus={autoFocus}
         keyboardType={keyboardType}
         onBlur={this.handlerOnBlur}
@@ -240,9 +241,7 @@ class ConfirmationCodeInput extends PureComponent<Props, State> {
         onPress={this.handlerOnPress}
         style={concatStyles(styles.maskInput, inputProps.style)}
         onChangeText={this.handlerOnTextChange}
-      >
-        {this.state.codeValue}
-      </TextInputCustom>
+      />
     );
   }
 

--- a/src/components/ConfirmationCodeInput/types.js
+++ b/src/components/ConfirmationCodeInput/types.js
@@ -40,6 +40,7 @@ export type Props = $ReadOnly<{|
   containerProps: ViewProps,
   inputProps: TextInputProp,
   testID?: any,
+  formatCode: (code: string) => string,
 |}>;
 
 export type State = {|


### PR DESCRIPTION
It will be helpful to have the ability to format entered code. e.g. when selected `keyboardType="number-pad"`, user still can type symbols `- , =` etc.
Using prop formatCode we can format code as we want.
Example: allow a user to enter only numbers
```
const format = (code) => {
  const numbers = code.match(/\d+/g);
  return numbers ? numbers.join('') : '';
};
...
<CodeInput
  ...
  keyboardType="number-pad"
  formatCode={format}
/>
```