### PR TITLE
Fix container collapse on iOS

### DIFF
--- a/src/components/ConfirmationCodeInput/styles.js
+++ b/src/components/ConfirmationCodeInput/styles.js
@@ -32,7 +32,6 @@ const positionMap = {
 export const getContainerStyle = ({ inputPosition, containerProps }: Props) =>
   concatStyles(
     {
-      flex: 1,
       flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row',
       justifyContent: positionMap[inputPosition],
     },


### PR DESCRIPTION
If apply `flex:1` for root `<View/>` as a result we get collapse to zero height container.
And all clicks did not fall into this container.

https://github.com/retyui/react-native-confirmation-code-field/issues/78