### PR TITLE
removed maxLength to allow pasting longer text than field

### DIFF
--- a/src/CodeField.tsx
+++ b/src/CodeField.tsx
@@ -83,7 +83,6 @@ function CodeFieldComponent(
         clearButtonMode="never"
         autoCapitalize="characters"
         underlineColorAndroid="transparent"
-        maxLength={cellCount}
         {...rest}
         value={value}
         onBlur={focusState.onBlur}


### PR DESCRIPTION
reason behind doing it is when copying from SMS, you are can copy full sms and it would not paste.. by doing so you can paste whole length and then when using it you can do something like this


> const onChange = useCallback((text: string) => {
>     text = text.replace(/\D/g, '').slice(0, 6)
>     setCode(text)
>   }, [])