### PR TITLE
chore: update tsconfig for jsx react

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/react-native/tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "types": ["react-native", "jest"],
     "rootDir": "./src",
     "module": "ES2020",


### PR DESCRIPTION
Resolves #243

This PR addresses a type warning by explicitly setting the jsx compiler option in tsconfig.json to "react".
This change updates the JSX type declarations from JSX.Element to React.JSX.Element, aligning with the latest TypeScript and React type definitions.

You can see changes after the compile library with tsc.